### PR TITLE
Update seafile-ce_ubuntu-trusty-arm

### DIFF
--- a/community-edition/seafile-ce_ubuntu-trusty-arm
+++ b/community-edition/seafile-ce_ubuntu-trusty-arm
@@ -564,7 +564,7 @@ update-rc.d seafile-server defaults
 adduser --system --gecos "${SEAFILE_USER}" ${SEAFILE_USER} --home /opt/seafile
 mkdir -p /opt/seafile/installed
 cd /opt/seafile/
-curl -OL https://github.com/haiwen/seafile-rpi/releases/download/v4.3.1/seafile-server_4.3.2_pi.tar.gz
+curl -OL https://github.com/haiwen/seafile-rpi/releases/download/v4.3.2/seafile-server_4.3.2_pi.tar.gz
 tar xzf seafile-server_4.3.2_pi.tar.gz
 
 SEAFILE_VERSION=$(basename /opt/seafile/seafile-server-* | awk -F'-' ' { print $3  }')

--- a/community-edition/seafile-ce_ubuntu-trusty-arm
+++ b/community-edition/seafile-ce_ubuntu-trusty-arm
@@ -564,12 +564,12 @@ update-rc.d seafile-server defaults
 adduser --system --gecos "${SEAFILE_USER}" ${SEAFILE_USER} --home /opt/seafile
 mkdir -p /opt/seafile/installed
 cd /opt/seafile/
-curl -OL https://github.com/haiwen/seafile-rpi/releases/download/v4.3.1/seafile-server_4.3.1_pi.tar.gz
-tar xzf seafile-server_4.3.1_pi.tar.gz
+curl -OL https://github.com/haiwen/seafile-rpi/releases/download/v4.3.1/seafile-server_4.3.2_pi.tar.gz
+tar xzf seafile-server_4.3.2_pi.tar.gz
 
 SEAFILE_VERSION=$(basename /opt/seafile/seafile-server-* | awk -F'-' ' { print $3  }')
 
-mv seafile-server_4.3.1_pi.tar.gz installed/seafile-server_${SEAFILE_VERSION}_pi.tar.gz
+mv seafile-server_4.3.2_pi.tar.gz installed/seafile-server_${SEAFILE_VERSION}_pi.tar.gz
 
 
 # -------------------------------------------


### PR DESCRIPTION
The current stable is 4.3.2, see https://github.com/haiwen/seafile-rpi
