### PR TITLE
Change 'spdy' in nginx seafile config

### DIFF
--- a/community-edition/seafile-ce_ubuntu-trusty-amd64
+++ b/community-edition/seafile-ce_ubuntu-trusty-amd64
@@ -125,7 +125,7 @@ server {
 }
 
 server {
-      listen 443 spdy;
+      listen 443 http2;
       server_name  "";
 
       ssl on;


### PR DESCRIPTION
For nginx version >= 1.9.5 paramter 'spdy' is 'http2' now.
See https://www.nginx.com/blog/nginx-1-9-5/
