### PR TITLE
Fix aptitude check

### DIFF
--- a/community-edition/seafile-ce_ubuntu-trusty-amd64
+++ b/community-edition/seafile-ce_ubuntu-trusty-amd64
@@ -86,15 +86,16 @@ fi
 
 
 # -------------------------------------------
+# Ensure aptitude is installed
+# -------------------------------------------
+apt-get install aptitude -y
+
+
+# -------------------------------------------
 # Update System
 # -------------------------------------------
 aptitude update && aptitude dist-upgrade -y
 
-
-# -------------------------------------------
-# Ensure aptitude is installed
-# -------------------------------------------
-apt-get install aptitude -y
 
 # -------------------------------------------
 # Additional requirements


### PR DESCRIPTION
aptitude is called before the check to make sure that it is indeed installed. This corrects the sequence.
