### PR TITLE
Create `seafile.conf` in central config dir

### DIFF
--- a/community-edition/seafile-ce_uberspace
+++ b/community-edition/seafile-ce_uberspace
@@ -325,7 +325,7 @@ eval "sed -i 's/^SERVICE_URL.*/SERVICE_URL = https:\/\/${WHOAMI}.${HOSTNAME}/' $
 # Create seafile conf
 # -------------------------------------------
 LD_LIBRARY_PATH=$SEAFILE_LD_LIBRARY_PATH ${SEAF_SERVER_INIT} --seafile-dir "${SEAFILE_DATA_DIR}" \
-  --port ${SEAFILE_PORT} --fileserver-port ${FILESERVER_PORT}
+  --central-config-dir "${DEFAULT_CONF_DIR}" --port ${SEAFILE_PORT} --fileserver-port ${FILESERVER_PORT}
 
 
 # -------------------------------------------


### PR DESCRIPTION
So far the seafile config was created in the `SEAFILE_DATA_DIR`. That
way it wasn't loaded, which prevented the creation of a session.

This commit calls `seaf-server-init` with the [`-F` flag](https://github.com/haiwen/seafile/blob/master/tools/seaf-server-init.c#L44) to make it create the `seafile.conf` in the `DEFAULT_CONF_DIR`, [as the default installer does](https://github.com/haiwen/seafile/blob/master/scripts/setup-seafile-mysql.py#L841).

Fixes issue SeafileDE/seafile-server-installer#55.
