### PR TITLE
Remove `/tmp/seahub_cache` on uninstall

### DIFF
--- a/community-edition/seafile-ce_uberspace_uninstall
+++ b/community-edition/seafile-ce_uberspace_uninstall
@@ -53,7 +53,7 @@ ps aux | grep sea | grep -v grep | grep -v uninstall | awk '{ print $2 }' | whil
 # -------------------------------------------
 # remove Seafile, Apache and Python 2.7 related directories and files
 # -------------------------------------------
-eval rm -r ~/seafile-ce_* ~/seafile/ ~/bin/seafile* ~/fcgi-bin/seahub* ~/html/.htaccess ~/bin ~/lib/python2.7 ${SILENCER}
+eval rm -r ~/seafile-ce_* ~/seafile/ ~/bin/seafile* ~/fcgi-bin/seahub* ~/html/.htaccess ~/bin ~/lib/python2.7 /tmp/seahub_cache ${SILENCER}
 
 
 # -------------------------------------------


### PR DESCRIPTION
So far the `/media/CACHE` dir wasn't deleted by the uninstaller, which
led to a `404` after a reinstall when requesting the `css` for the
seafile home page. Cf haiwen/seafile#1261.

This commit removes the conflicting directory so that is gets recreated
after a reinstallation.
